### PR TITLE
fix for dplyr 1.0.8

### DIFF
--- a/vignettes/functiondepends-usage.Rmd
+++ b/vignettes/functiondepends-usage.Rmd
@@ -117,7 +117,7 @@ library(igraph)
 
 edges <- dependency %>% 
   select(Source, Target) %>% 
-  filter(!is.na(.))
+  na.omit()
 
 vertices <- unique(c(dependency$Source, dependency$Target))
 vertices <- vertices[!is.na(vertices)]
@@ -141,7 +141,8 @@ plot(
 dependency <- find_dependencies(unique(functions$Function), envir = envir, in_envir = FALSE)
 edges <- dependency %>% 
   select(Source, Target) %>% 
-  filter(!is.na(.))
+  na.omit()
+
 vertices <- unique(c(edges$Source, edges$Target))
 
 g <- graph_from_data_frame(edges)


### PR DESCRIPTION
In dplyr 1.0.8, which is about to be released, `filter()` got stricter about matrix inputs, which is what `is.na(.)` was making. 

Please consider releasing with this simple fix. Alternatively you could use `filter(if_any(everything(), is.na))` but it seems `na.omit()` does the job. 